### PR TITLE
choose different font if comic.ttf is not available (for linux support)

### DIFF
--- a/PixelGunCheat/Cheat/Gui/imgui_hooker.cpp
+++ b/PixelGunCheat/Cheat/Gui/imgui_hooker.cpp
@@ -495,6 +495,15 @@ void BKCImGuiHooker::setup_imgui_hwnd(HWND handle, void* device, void* device_co
     multi_out << "Using " << scale_factor << "x scale factor for ImGui fonts";
     Logger::log_info(multi_out.str());
 
+    if (!std::filesystem::exists(current_font)){
+        for (const auto &entry : std::filesystem::directory_iterator("C:/Windows/Fonts/")){
+            if (entry.path().extension() == ".ttf"){
+                current_font = entry.path().string();
+                break;
+            }
+        }
+    }
+
     // create font from file (thank god doesn't need to be only loaded from memory, but still can be)
     gui_font = io.Fonts->AddFontFromFileTTF(current_font.c_str(), 20.0f * scale_factor);
     watermark_font = io.Fonts->AddFontFromFileTTF(current_font.c_str(), 32.0f * scale_factor);
@@ -537,6 +546,14 @@ void BKCImGuiHooker::start(void* g_mainRenderTargetView, void* g_pd3dDevice, voi
     {
         font_changed = false;
         ImGuiIO& io2 = ImGui::GetIO(); (void) io2;
+        if (!std::filesystem::exists(current_font)){
+            for (const auto &entry : std::filesystem::directory_iterator("C:/Windows/Fonts/")){
+                if (entry.path().extension() == ".ttf"){
+                    current_font = entry.path().string();
+                    break;
+                }
+            }
+        }
         gui_font = io2.Fonts->AddFontFromFileTTF(current_font.c_str(), 20.0f * scale_factor);
         watermark_font = io2.Fonts->AddFontFromFileTTF(current_font.c_str(), 32.0f * scale_factor);
         arraylist_font = io2.Fonts->AddFontFromFileTTF(current_font.c_str(), 24.0f * scale_factor);

--- a/PixelGunCheat/dllmain.cpp
+++ b/PixelGunCheat/dllmain.cpp
@@ -22,6 +22,7 @@
 HWND window = NULL;
 WNDPROC oWndProc;
 bool dx11 = false;
+bool fg = false;
 ID3D11Device* pDevice11 = NULL;
 ID3D11DeviceContext* pContext11 = NULL;
 ID3D11RenderTargetView* mainRenderTargetView11;
@@ -134,6 +135,17 @@ LRESULT __stdcall WndProc(const HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPara
     
     switch (msg)
     {
+    case WM_ACTIVATE: {
+        if (LOWORD(wParam) == 0) {
+            ClipCursor(NULL);
+            fg = false;
+            return CallWindowProcW(oWndProc, GetActiveWindow(), msg, wParam, lParam);
+        }
+        else {
+            fg = true;
+        }
+        break;
+    }
     case WM_MOUSEMOVE:
         HandleMouseInputs(hWnd, io);
         break;
@@ -195,7 +207,7 @@ LRESULT __stdcall WndProc(const HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPara
         confineRect.right = center.x + 10;
         confineRect.top = center.y - 10;
         confineRect.bottom = center.y + 10;
-        if (center.x >= 0 && center.y >= 0) ClipCursor(&confineRect);
+        if (center.x >= 0 && center.y >= 0 && fg) ClipCursor(&confineRect);
         return CallWindowProcW(oWndProc, GetActiveWindow(), msg, wParam, lParam);
     }
     ClipCursor(NULL);


### PR DESCRIPTION
if comic.ttf font does not exist it will choose different font from C:/Windows/Fonts/ to use instead this makes it work on linux with wine/proton out of the box without needing to add the font manually