### PR TITLE
unfuck arrow key user's mums

### DIFF
--- a/PixelGunCheat/Cheat/Data/Currency.h
+++ b/PixelGunCheat/Cheat/Data/Currency.h
@@ -15,5 +15,4 @@ static inline std::vector<std::wstring> currency_names = {
     L"BattlePassCurrency",
     L"CurrencyCompetitionTier1",
     L"CurrencyCompetitionTier2",
-    L"PixelBucks",
 };


### PR DESCRIPTION
you did two pixelbucks (currency made to make you waste your real currency) and it fucks arrow key's users mums over and they're ind ebt


the slider loops pixelbucks and u cant go up or back down.....
cuz u duped the pixelbucks

i dont know my build doesnt include whatever the new gui revamp is

